### PR TITLE
Fix brew path detection and git exclude path

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,5 +1,5 @@
 [core]
-	excludesfile = /Users/travis/.gitignore
+        excludesfile = ~/.gitignore
 [credential]
 	helper = /usr/local/share/gcm-core/git-credential-manager
 [credential "https://dev.azure.com"]

--- a/setup.sh
+++ b/setup.sh
@@ -15,9 +15,21 @@ if ! command -v brew &> /dev/null; then
 fi
 
 # Add brew to the path for the brewfile installation 
-echo >> $HOME/.zprofile
-echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> $HOME/.zprofile
-eval "$(/opt/homebrew/bin/brew shellenv)"
+echo >> "$HOME/.zprofile"
+
+# Determine Homebrew path for different platforms
+if [[ -x "/opt/homebrew/bin/brew" ]]; then
+  BREW_PATH="/opt/homebrew/bin/brew"
+elif [[ -x "/usr/local/bin/brew" ]]; then
+  BREW_PATH="/usr/local/bin/brew"
+elif [[ -x "/home/linuxbrew/.linuxbrew/bin/brew" ]]; then
+  BREW_PATH="/home/linuxbrew/.linuxbrew/bin/brew"
+else
+  BREW_PATH="$(command -v brew)"
+fi
+
+echo "eval \"\$(${BREW_PATH} shellenv)\"" >> "$HOME/.zprofile"
+eval "$(${BREW_PATH} shellenv)"
 
 # Install all packages from Brewfile
 brew bundle --file="Brewfile"


### PR DESCRIPTION
## Summary
- resolve absolute path for git ignore file
- make brew path detection cross-platform in setup script

## Testing
- `bash -n setup.sh`
- `bash -n gitsetup.sh`
- `bash -n backup.sh`
- `bash -n change-alacritty-icon.sh`


------
https://chatgpt.com/codex/tasks/task_e_683fb1627d9083209574f101ce9694c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Git configuration to use a home directory reference for the global excludes file.
  - Improved Homebrew setup script to detect and support multiple installation locations across different platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->